### PR TITLE
Remove the nether kingdom from classic

### DIFF
--- a/nether_kingdom/map.conf
+++ b/nether_kingdom/map.conf
@@ -17,4 +17,4 @@ phys_gravity = 1
 chests = return {{["pos2"] = {["y"] = 24, ["x"] = 212, ["z"] = 212}, ["pos1"] = {["y"] = 18, ["x"] = 0, ["z"] = 0}, ["amount"] = 42}}
 teams = return {["purple"] = {["pos2"] = {["y"] = 0, ["x"] = 111, ["z"] = 106}, ["enabled"] = true, ["pos1"] = {["y"] = 62, ["x"] = 0, ["z"] = 0}, ["flag_pos"] = {["y"] = 22, ["x"] = 36, ["z"] = 41}}, ["green"] = {["pos2"] = {["y"] = 62, ["x"] = 212, ["z"] = 0}, ["enabled"] = true, ["pos1"] = {["y"] = 0, ["x"] = 111, ["z"] = 106}, ["flag_pos"] = {["y"] = 22, ["x"] = 185, ["z"] = 21}}, ["orange"] = {["pos2"] = {["y"] = 0, ["x"] = 111, ["z"] = 106}, ["enabled"] = true, ["pos1"] = {["y"] = 62, ["x"] = 212, ["z"] = 212}, ["flag_pos"] = {["y"] = 22, ["x"] = 171, ["z"] = 171}}, ["blue"] = {["pos2"] = {["y"] = 62, ["x"] = 0, ["z"] = 212}, ["enabled"] = true, ["pos1"] = {["y"] = 0, ["x"] = 111, ["z"] = 106}, ["flag_pos"] = {["y"] = 22, ["x"] = 21, ["z"] = 191}}}
 barrier_area = return {["pos1"] = {["y"] = 62, ["x"] = 212, ["z"] = 212}, ["pos2"] = {["y"] = 0, ["x"] = 0, ["z"] = 0}}
-game_modes = return {"classes", "classic", "nade_fight"}
+game_modes = return {"classes", "nade_fight"}


### PR DESCRIPTION
The nether kingdom map is bad for classic because there are no ores. The only way to get swords is by looting chests, but most chests don't have swords.