### PR TITLE
Fix Chest Spawn on Snowland

### DIFF
--- a/snowland/map.conf
+++ b/snowland/map.conf
@@ -14,7 +14,7 @@ start_time = 5900
 phys_speed = 1
 phys_jump = 1
 phys_gravity = 1
-chests = return {{pos1={z=0,x=0,y=0},pos2={z=230,x=230,y=140},amount=42}}
+chests = return {{pos1={x=5,y=17,z=115},pos2={x=225,y=140,z=225},amount=21},{pos1={x=5,y=17,z=5},pos2={x=225,y=140,z=115},amount=21}}
 teams = local _={};_[1]="flag_pos";_[2]="enabled";return {blue={[_[1]]={z=39,x=106,y=22},pos1={z=115,x=225,y=140},pos2={z=5,x=5,y=0},[_[2]]=true},red={[_[1]]={z=197,x=159,y=28},pos1={z=115,x=225,y=140},pos2={z=225,x=5,y=0},[_[2]]=true}}
 barrier_area = return {pos2={z=230,x=230,y=140},pos1={z=0,x=0,y=0}}
 game_modes = return {"classes","nade_fight","classic"}


### PR DESCRIPTION
This PR fixes a few issues with the way chests spawn on "Snowland"

- One chest zone that used to cover the whole map has been divided into two, giving each team an equal number of chests. The total number of chests has not been changed.
- The chest zone has been shrunk so chests no longer spawn outside of the border, and therefore out of reach of players.
- Chests no longer spawn in underground dungeons