### PR TITLE
Make blocks found in chests more appropriate for certain maps

### DIFF
--- a/ahkmenrah_pyramids/map.conf
+++ b/ahkmenrah_pyramids/map.conf
@@ -8,7 +8,7 @@ time_speed = 1
 size = return {z=218,x=218,y=60}
 hint = There is an invisible labyrinth under your base and a treasure at the end of it!
 others = 
-treasures = return {"none"}
+treasures = default:cobble;0;0;0;0.0;1;default:desert_cobble;50;99;2;0.3;1;
 skybox = none
 start_time = 5900
 phys_speed = 1

--- a/capture_legend/map.conf
+++ b/capture_legend/map.conf
@@ -8,7 +8,7 @@ time_speed = 1
 size = return {z=174,x=174,y=108}
 hint = Look in the castle for some chests.
 others = 
-treasures = 
+treasures = default:cobble;0;0;0;0.0;1;default:stonebrick;50;99;2;0.3;1; 
 skybox = capture_legend
 start_time = 5900
 phys_speed = 1

--- a/ewok_village/map.conf
+++ b/ewok_village/map.conf
@@ -8,7 +8,7 @@ time_speed = 1
 size = return {z=100,x=100,y=120}
 hint = 
 others = 
-treasures = return {}
+treasures = default:wood;0;0;0;0.0;1;default:junglewood;50;99;2;0.2;1;
 skybox = none
 start_time = 5900
 phys_speed = 1

--- a/nether_kingdom/map.conf
+++ b/nether_kingdom/map.conf
@@ -8,7 +8,7 @@ time_speed = 1
 size = return {z=212,x=212,y=62}
 hint = 
 others = 
-treasures = return {"none"}
+treasures = default:cobble;0;0;0;0.0;1;default:desert_cobble;50;99;2;0.3;1;
 skybox = none
 start_time = 5900
 phys_speed = 1


### PR DESCRIPTION
Specifically on maps that spawn players with blocks different than "chest blocks" (cobble or wood), matches chest blocks to the default block.

Maps currently affected:
- Ewok Village (All wood in chests is now jungle wood)
- Nether Kingdom (All cobble in chests is now desert cobble)
- Pyramids of Akhenaten (All cobble in chests is now desert cobble)